### PR TITLE
chore(npm): Add .npmrc

### DIFF
--- a/lab-1/.npmrc
+++ b/lab-1/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/lab-2/.npmrc
+++ b/lab-2/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/lab-3/.npmrc
+++ b/lab-3/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/lab-4/.npmrc
+++ b/lab-4/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/lab-5/.npmrc
+++ b/lab-5/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/lab-6/.npmrc
+++ b/lab-6/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/playground/bulkhead/.npmrc
+++ b/playground/bulkhead/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/playground/reconciliation/.npmrc
+++ b/playground/reconciliation/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
# Add .npmrc to specify npm registry

This PR adds a `.npmrc` file to the project root with the following content:

## Rationale

1. **Prevent conflicts:** Explicitly setting the npm registry helps prevent potential conflicts with enterprise registries that developers might have configured globally on their machines.

2. **Streamline setup:** By including this `.npmrc` file in the repository, we eliminate the need for developers to manually copy and paste this configuration into all sub-packages. This saves time and reduces the chance of setup errors during the workshop

## Impact

This change should have no negative impact on existing workflows. It simply makes the npm registry explicit for this project, which can help prevent issues and speed up the development process.
